### PR TITLE
[S2-446]파일을 실시간 처럼 보내도록 수정

### DIFF
--- a/python-stt-sample/src/sample_stt.py
+++ b/python-stt-sample/src/sample_stt.py
@@ -38,7 +38,10 @@ GRPC_SERVER_URL = "grpc-openapi.vito.ai:443"
 
 SAMPLE_RATE = 8000
 ENCODING = pb.DecoderConfig.AudioEncoding.LINEAR16
+BYTES_PER_SAMPLE= 2
 
+# 본 예제에서는 스트리밍 입력을 음성파일을 읽어서 시뮬레이션 합니다.
+# 실제사용시에는 마이크 입력 등의 실시간 음성 스트림이 들어와야합니다.
 class FileStreamer:    
     def __init__(self,filepath):
         self.filepath = filepath
@@ -48,11 +51,12 @@ class FileStreamer:
         return self
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.file.close()
+        os.remove(self.filepath)
         
     def read(self, size):
         if size > 1024 * 1024:
             size = 1024*1024
-        time.sleep(size / 16 / 1000)
+        time.sleep(size / (SAMPLE_RATE*BYTES_PER_SAMPLE))
         content = self.file.read(size)
         return content
 

--- a/python-stt-sample/src/sample_stt.py
+++ b/python-stt-sample/src/sample_stt.py
@@ -42,7 +42,6 @@ ENCODING = pb.DecoderConfig.AudioEncoding.LINEAR16
 class FileStreamer:
     def __init__(self, filepath):
         self.file = open(filepath,"rb")
-        self._logger = logging.getLogger(__name__)
 
     def read(self, size):
         if size > 1024 * 1024:


### PR DESCRIPTION
> 현재는 파일을 읽어서 전체를 한번에 던지는 형태
> 해당 예제코드에 사용하는 음성파일은 작으나 큰 파일을 해당방식으로 던질 경우 istio-proxy가 터지거나 오류 발생
> 음성 실제 길이에 맞춰서 delay를 주면서 전송하는 형태로 바꿔야합니다.

기존에 8k wav만 input으로 넣을 수 있어서 변환은 안했습니다.
soundfile 모듈을 사용하는데 안내가 없어서 추가했습니다
SAMPLE_RATE 16000으로 정의되어있는데, 해당 변수와 비교 후 8000이어야한다는 에러를 반환하는 것을 보고, 8000으로 바꿨습니다
읽은 파일의 바이트만큼 대기하여 실시간 처럼 파일을 보내도록 수정했습니다
읽은 파일의 바이트가 1MB 초과하면 1MB만 읽도록 수정했습니다 

(troye가 작성하셨길래 reviewer assign 하려했는데 할수가없네요 ㅎㅎ..) 